### PR TITLE
paste fix

### DIFF
--- a/CodePen/JS.js
+++ b/CodePen/JS.js
@@ -907,8 +907,10 @@ function hideIntroGif() {
 function removeStylingFromPastedText() {
   $(window).on("paste", function (event) {
     event.preventDefault();
-    var data = event.originalEvent.clipboardData.getData("Texts");
-    document.execCommand("insertText", false, data);
+    if (event.originalEvent && event.originalEvent.clipboardData) {
+      const data = event.originalEvent.clipboardData.getData("text");
+      document.execCommand("insertText", false, data);
+    }
   });
 }
 makeInputLabelsSmarter("radio");

--- a/index.js
+++ b/index.js
@@ -905,7 +905,9 @@ function hideIntroGif() {
 function removeStylingFromPastedText() {
   $(window).on("paste", function (event) {
     event.preventDefault();
-    var data = event.originalEvent.clipboardData.getData("Texts");
-    document.execCommand("insertText", false, data);
+    if (event.originalEvent && event.originalEvent.clipboardData) {
+      const data = event.originalEvent.clipboardData.getData("text");
+      document.execCommand("insertText", false, data);
+    }
   });
 }


### PR DESCRIPTION
# Problem/Need:

Pasting into the `contenteditable`s and into the table should be possible.

<!-- issue # or problem description or why something should be fixed/added -->

# Suggested changes:

Upon inspecting the `paste` event listener on the `window`, it turns out that pasting isn't working, even in https

<!-- to make it easier to review, here's a general summary of what I did to fix it or improve it: -->

<!-- automated tests I ran (if available) -->

# Reminders for @hchiam:

- [ ] `yarn deploy` to update surge site
- [x] update <https://codepen.io/hchiam/pen/jOBOaqm>
